### PR TITLE
Hubot now can flip the table repeatedly

### DIFF
--- a/hubot/scripts/tableflip.coffee
+++ b/hubot/scripts/tableflip.coffee
@@ -23,7 +23,7 @@ table_flipper = (robot, msg) ->
     robot.brain.set "table_flip_state", "upright"
   else
     msg.send "(╯°□°）╯︵ ┻━┻"
-  robot.brain.set "table_flip_state", "flipped"
+    robot.brain.set "table_flip_state", "flipped"
 
 table_restorer = (robot, msg) ->
   if (robot.brain.get "table_flip_state") == "flipped"
@@ -33,9 +33,9 @@ table_restorer = (robot, msg) ->
     msg.send "┬─┬ ヽ( ° _ °)ノ"
 
 module.exports = (robot) ->
-  robot.hear /table[ ]?flip/i, (msg) -> table_flipper(robot,msg)
+  robot.hear /table[ ]?flip/i, (msg) -> table_flipper(robot, msg)
 
-  robot.hear /flip(ping)? table/i, (msg) -> table_flipper(robot,msg)
+  robot.hear /flip(ping)? table/i, (msg) -> table_flipper(robot, msg)
 
   robot.hear /table[ ]restore/i, (msg) -> table_restorer(robot, msg)
 

--- a/hubot/scripts/tableflip.coffee
+++ b/hubot/scripts/tableflip.coffee
@@ -17,16 +17,26 @@
 #   gavinheavyside
 #
 
+table_flipper = (robot, msg) ->
+  if (robot.brain.get "table_flip_state") == "flipped"
+    msg.send "(╯°□°）╯︵ ┬─┬"
+    robot.brain.set "table_flip_state", "upright"
+  else
+    msg.send "(╯°□°）╯︵ ┻━┻"
+  robot.brain.set "table_flip_state", "flipped"
+
+table_restorer = (robot, msg) ->
+  if (robot.brain.get "table_flip_state") == "flipped"
+    msg.send "┬─┬ノ( º _ ºノ)"
+    robot.brain.set "table_flip_state", "upright"
+  else
+    msg.send "┬─┬ ヽ( ° _ °)ノ"
 
 module.exports = (robot) ->
-  robot.hear /table[ ]?flip/i, (msg) ->
-    msg.send "(╯°□°）╯︵ ┻━┻"
+  robot.hear /table[ ]?flip/i, (msg) -> table_flipper(robot,msg)
 
-  robot.hear /flip(ping)? table/i, (msg) ->
-    msg.send "(╯°□°）╯︵ ┻━┻"
+  robot.hear /flip(ping)? table/i, (msg) -> table_flipper(robot,msg)
 
-  robot.hear /table[ ]restore/i, (msg) ->
-    msg.send "┬─┬ノ( º _ ºノ)"
+  robot.hear /table[ ]restore/i, (msg) -> table_restorer(robot, msg)
 
-  robot.hear /patience young grasshopper/i, (msg) ->
-    msg.send "┬─┬ノ( º _ ºノ)"
+  robot.hear /patience young grasshopper/i, (msg) -> table_restorer(robot, msg)


### PR DESCRIPTION
Hubot table flip currently will continue to flip the table upside down, even if it is already flipped. 

This allows the table to be restored to it's original position by re-flipping and for the bot to look confused and raise it's hands when you ask it to restore the table when it's already fine.