### PR TITLE
Updated locally running drivebot with AWS MFA tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ docker run --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
                 --name drivebot mydrive/drivebot:1.3
 ```
 
+*The above script assumes that AWS MFA credentials are in your ENV and are not older than one hour, so have not expired.*
+
 When you're happy, push to the registry
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 
-building and running locally, bump the version tag e.g.
+# Building and running locally
+
+## Prerequisites
+
+When running locally, i.e. not on an EC2 instance, the container requires you pass in AWS MFA credentials. The method described here requires the credentials to in be your ENV and not to be older than one hour, otherwise they would have expired. The credentials are only required on starting the container.
+
+One method to get the credentials into your ENV is to use the MyDrive AWS MFA script: https://github.com/mydrive/mydrive-aws-mfa#quiet
+
+## Steps
+
+1) Build the docker image and tag it, bumping the version tag:
 
 ```
 docker build --rm -t mydrive/drivebot:1.3 .
+```
 
+2) Run the docker container, passing in the AWS credentials:
+
+```
 docker run --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
                 -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
                 -e "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" \
@@ -13,15 +27,13 @@ docker run --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
                 --name drivebot mydrive/drivebot:1.3
 ```
 
-*The above script assumes that AWS MFA credentials are in your ENV and are not older than one hour, so have not expired.*
-
-When you're happy, push to the registry
+3) When you're happy, push the image to the registry:
 
 ```
 docker push mydrive/drivebot:1.3
 ```
 
-Deploying:
+# Deploying
 
 Edit the tag in the terraform file, to upgrade the version in the ECS task
 definition

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ building and running locally, bump the version tag e.g.
 ```
 docker build --rm -t mydrive/drivebot:1.3 .
 
-docker run --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" --name drivebot mydrive/drivebot:1.3
+docker run --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
+                -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
+                -e "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" \
+                -e "AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}" \
+                -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" \
+                -e "AWS_REGION=${AWS_REGION}" \
+                --name drivebot mydrive/drivebot:1.3
 ```
 
 When you're happy, push to the registry


### PR DESCRIPTION
Since we introduced AWS MFA tokens, the description for running the docker container locally has been outdated.

This PR updates the README to pass in the extra credentials required by AWS MFA. It assumes the user runs the AWS MFA script before running the `docker run ...` command

There may be other ways to go about this:
* Mounting the ~/.aws folder to the container.
* Running the AWS MFA script from within the docker container and adding the 6 digit code interactively.