### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get clean && \
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 RUN npm install -g coffee-script
-RUN npm install -g yo generator-hubot
+RUN npm install -g yo@1.8.5 generator-hubot
 
 # Create hubot user
 RUN useradd -d /hubot -m -s /bin/bash -U hubot

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker build --rm -t mydrive/drivebot:1.3 .
 docker run --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
                 -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
                 -e "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" \
-                -e "AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}" \
+                -e "AWS_SECURITY_TOKEN=${AWS_SESSION_TOKEN}" \
                 -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" \
                 -e "AWS_REGION=${AWS_REGION}" \
                 --name drivebot mydrive/drivebot:1.3


### PR DESCRIPTION
The version of node being installed in the docker container is 4.2.6, which is now EOL; it appears that any version of yo past 1.8.5 is incompatible with this, and as such I've pinned the version as a workaround.

Updated the README run command example to set the `AWS_SECURITY_TOKEN` environment variable to be the `AWS_SESSION_TOKEN`; without this, the `aws cp` command fails with a permissions error.