### PR TITLE
[WAFL-456] Send Badger usage metrics to SignalFX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN npm install hubot-pugme --save && npm install
 RUN npm install hubot-standup-alarm --save && npm install
 RUN npm install hubot-google-images --save && npm install
 RUN npm install hubot-redis-brain --save && npm install
+RUN npm install signalfx --save && npm install
 # RUN npm install hubot-auth --save && npm install
 # RUN npm install hubot-google-translate --save && npm install
 # RUN npm install hubot-auth --save && npm install

--- a/hubot/scripts/badger.coffee
+++ b/hubot/scripts/badger.coffee
@@ -27,20 +27,44 @@
 #   matthewhinks, gavin
 #
 
+signalfx = require('signalfx')
+signalfx_client = new signalfx.Ingest(process.env.SIGNALFX_API_TOKEN)
+SIGNALFX_SUCCESSFUL = "successful"
+SIGNALFX_FAILED = "failed"
+
+send_signalfx_metric = (metric_name, dimensions) ->
+  timestamp = new Date().getTime()
+  metric = {
+    metric: metric_name,
+    value: 1,
+    timestamp: timestamp,
+    dimensions: dimensions
+  }
+
+  signalfx_client.send({ counters:[metric] })
+
 badger_free = (robot, msg) ->
   current_owner = robot.brain.get "badger_owner" || ""
 
   message_sender = msg.message.user.name.toLowerCase()
 
+  signalfx_metric_name = "badger.free"
+  signalfx_metric_dimensions = { message_sender: message_sender }
+
   if current_owner == ""
+    signalfx_metric_dimensions.result = SIGNALFX_FAILED
     msg.send ":badger: is already in the wild"
   else if current_owner == message_sender
     robot.brain.set "badger_owner", ""
     robot.brain.set "badger_time", ""
 
+    signalfx_metric_dimensions.result = SIGNALFX_SUCCESSFUL
     msg.send ":badger: was released into the wild by #{current_owner}"
   else
+    signalfx_metric_dimensions.result = SIGNALFX_FAILED
     msg.send ":badger: is currently in the care of #{current_owner}, please wait for them to free the badger"
+
+  send_signalfx_metric(signalfx_metric_name, signalfx_metric_dimensions)
 
 badger_steal = (robot, msg) ->
   current_owner = robot.brain.get "badger_owner" || ""
@@ -48,10 +72,15 @@ badger_steal = (robot, msg) ->
 
   message_sender = msg.message.user.name.toLowerCase()
 
+  signalfx_metric_name = "badger.steal"
+  signalfx_metric_dimensions = { message_sender: message_sender }
+
   if current_owner == ""
     robot.brain.set "badger_owner", message_sender
+    signalfx_metric_dimensions.result = SIGNALFX_SUCCESSFUL
     msg.send ":badger: moved from the wild to the care of #{message_sender}"
   else if current_owner == message_sender
+    signalfx_metric_dimensions.result = SIGNALFX_FAILED
     msg.send ":badger: is already in the care of #{current_owner}"
   else
     robot.brain.set "badger_owner", message_sender
@@ -60,13 +89,19 @@ badger_steal = (robot, msg) ->
     date_time = now.toUTCString()
     robot.brain.set "badger_time", date_time
 
+    signalfx_metric_dimensions.result = SIGNALFX_SUCCESSFUL
     msg.send ":badger: was stolen from #{current_owner} by #{message_sender}"
+
+  send_signalfx_metric(signalfx_metric_name, signalfx_metric_dimensions)
 
 badger_take = (robot, msg) ->
   current_owner = robot.brain.get "badger_owner" || ""
   badger_time = robot.brain.get "badger_time" || ""
 
   message_sender = msg.message.user.name.toLowerCase()
+
+  signalfx_metric_name = "badger.take"
+  signalfx_metric_dimensions = { message_sender: message_sender }
 
   if current_owner == ""
     robot.brain.set "badger_owner", message_sender
@@ -75,20 +110,32 @@ badger_take = (robot, msg) ->
     date_time = now.toUTCString()
     robot.brain.set "badger_time", date_time
 
+    signalfx_metric_dimensions.result = SIGNALFX_SUCCESSFUL
     msg.send ":badger: moved from the wild to the care of #{message_sender}"
   else if current_owner == message_sender
+    signalfx_metric_dimensions.result = SIGNALFX_FAILED
     msg.send ":badger: is already in the care of #{current_owner} since #{badger_time}"
   else
+    signalfx_metric_dimensions.result = SIGNALFX_FAILED
     msg.send "#{current_owner} has had :badger: since #{badger_time}, go badger them"
+
+  send_signalfx_metric(signalfx_metric_name, signalfx_metric_dimensions)
 
 badger_where = (robot, msg) ->
   current_owner = robot.brain.get "badger_owner" || ""
   badger_time = robot.brain.get "badger_time" || ""
 
+  message_sender = msg.message.user.name.toLowerCase()
+
+  signalfx_metric_name = "badger.where"
+  signalfx_metric_dimensions = { message_sender: message_sender, result: SIGNALFX_SUCCESSFUL }
+
   if current_owner == ""
     msg.send ":badger: is currently in the wild"
   else
     msg.send ":badger: is currently in the care of #{current_owner} since #{badger_time}"
+
+  send_signalfx_metric(signalfx_metric_name, signalfx_metric_dimensions)
 
 module.exports = (robot) ->
   robot.hear /badger[ ]?take/i, (msg) -> badger_take(robot, msg)


### PR DESCRIPTION
Each badger command has it's own metric name. The user who sent the command and the result are sent as metric dimensions.

The SignalFX access token is stored in the existing env file on S3.

[Ticket](https://mydrive.atlassian.net/browse/WAFL-456).